### PR TITLE
Add `set_crs` CLI command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ Commands:
   mask           Create a NetCDF mask from a shapefile
   render_netcdf  Render netcdf files to images
   render_tif     Render Single-Band GeoTIFF files to images
+  set_crs        Set CRS information for variables in a dataset
   stats          Display statistics for variables within netCDF files
   to_netcdf      Convert rasters to NetCDF
   variables      List variables in netCDF file
@@ -248,6 +249,20 @@ Options:
 ## Render a GeoTIFF
 
 _likely to go away or be refactored in a major way_
+
+## Set CRS information for NetCDF variables
+
+`set_crs` sets coordinate reference (CRS) information for one or more 
+variables in a dataset.
+
+```
+> trefoil set_crs --help
+Usage: trefoil set_crs [OPTIONS] FILENAME PROJ4
+
+Options:
+--only TEXT  Set CRS only for the specified variables
+--help       Show this message and exit.
+```
 
 ## Display statistics for NetCDF variables
 

--- a/trefoil/cli/crs.py
+++ b/trefoil/cli/crs.py
@@ -1,0 +1,37 @@
+import click
+from netCDF4._netCDF4 import Dataset
+from pyproj import Proj
+
+from trefoil.netcdf import crs
+from trefoil.cli import cli
+
+
+@cli.command(short_help='Set spatial reference information for a variable in an existing dataset')
+@click.argument('filename', type=click.Path(exists=True))
+@click.argument('proj4')
+@click.argument('variables', required=False)
+@click.option('--all', 'all_variables', is_flag=True, default=False, help='Set CRS for all variables in the dataset')
+def set_crs(filename, proj4, variables, all_variables):
+    if not variables and not all_variables:
+        raise click.BadArgumentUsage('No variables specified')
+
+    try:
+        proj = Proj(proj4)
+    except RuntimeError:
+        raise click.BadArgumentUsage('Invalid projection: ' + proj4)
+
+    with Dataset(filename, 'a') as ds:
+        variables_li = []
+        if all_variables:
+            variables_li = list(ds.variables.keys())
+        elif variables:
+            variables_li = [x.strip() for x in variables.split(',')]
+            bad_variables = set(variables_li).difference(ds.variables.keys())
+            if bad_variables:
+                raise click.BadArgumentUsage(
+                    'The following variables do not exist in this dataset: ' + ', '.join(bad_variables)
+                )
+
+        for variable in variables_li:
+            crs.set_crs(ds, variable, proj)
+

--- a/trefoil/cli/crs.py
+++ b/trefoil/cli/crs.py
@@ -1,5 +1,5 @@
 import click
-from netCDF4._netCDF4 import Dataset
+from netCDF4 import Dataset
 from pyproj import Proj
 
 from trefoil.netcdf import crs

--- a/trefoil/cli/crs.py
+++ b/trefoil/cli/crs.py
@@ -6,25 +6,20 @@ from trefoil.netcdf import crs
 from trefoil.cli import cli
 
 
-@cli.command(short_help='Set spatial reference information for a variable in an existing dataset')
+@cli.command(short_help='Set spatial reference information for variables in an existing dataset')
 @click.argument('filename', type=click.Path(exists=True))
 @click.argument('proj4')
-@click.argument('variables', required=False)
-@click.option('--all', 'all_variables', is_flag=True, default=False, help='Set CRS for all variables in the dataset')
-def set_crs(filename, proj4, variables, all_variables):
-    if not variables and not all_variables:
-        raise click.BadArgumentUsage('No variables specified')
-
+@click.option('--only', 'variables', default=None, help='Set CRS only for the specified variables')
+def set_crs(filename, proj4, variables):
     try:
         proj = Proj(proj4)
     except RuntimeError:
         raise click.BadArgumentUsage('Invalid projection: ' + proj4)
 
     with Dataset(filename, 'a') as ds:
-        variables_li = []
-        if all_variables:
-            variables_li = list(ds.variables.keys())
-        elif variables:
+        if not variables:
+            variables_li = [v for v in ds.variables if v not in ds.dimensions]
+        else:
             variables_li = [x.strip() for x in variables.split(',')]
             bad_variables = set(variables_li).difference(ds.variables.keys())
             if bad_variables:

--- a/trefoil/cli/main.py
+++ b/trefoil/cli/main.py
@@ -2,6 +2,7 @@ from trefoil.cli import cli
 
 from trefoil.cli.calc import delta, bin_ts
 from trefoil.cli.convert import to_netcdf
+from trefoil.cli.crs import set_crs
 from trefoil.cli.extract import extract
 from trefoil.cli.info import describe, variables, stats
 from trefoil.cli.mask import mask


### PR DESCRIPTION
This PR adds a `set_crs` command to the CLI, similar to the `set_crs()` NetCDF API function.

Example usage:

```bash
$ trefoil set_crs dataset.nc "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" var1,var2
```

```bash
$ trefoil set_crs dataset.nc "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" --all
```