### PR TITLE
Add support for pyproj 2+

### DIFF
--- a/trefoil/netcdf/crs.py
+++ b/trefoil/netcdf/crs.py
@@ -10,10 +10,16 @@ https://github.com/NCPP/ocgis/blob/master/src/ocgis/interface/base/crs.py
 import logging
 import os
 import re
-from pyproj import Proj, pj_list, pj_ellps, pyproj_datadir
+from pyproj import Proj, pj_list, pj_ellps
 
 from trefoil.netcdf.utilities import get_ncattrs, set_ncattrs
 from rasterio.crs import CRS
+
+try:
+    from pyproj import pyproj_datadir
+except ImportError:
+    from pyproj import datadir
+    pyproj_datadir = datadir.get_data_dir()
 
 
 PROJ4_GEOGRAPHIC = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'

--- a/trefoil/netcdf/crs.py
+++ b/trefoil/netcdf/crs.py
@@ -15,6 +15,7 @@ from pyproj import Proj, pj_list, pj_ellps
 from trefoil.netcdf.utilities import get_ncattrs, set_ncattrs
 from rasterio.crs import CRS
 
+# pyproj 2 drops `pyproj_datadir` in favor of `datadir.get_data_dir()`
 try:
     from pyproj import pyproj_datadir
 except ImportError:


### PR DESCRIPTION
Trefoil doesn't currently work with pyproj version 2 and higher (version 3 is now the latest) due to a deprecated import of `pyproj_datadir`. This PR adds support for version 2+ while maintaining current compatibility by falling back to newer functionality when import of `pyproj_datadir` fails.