### PR TITLE
Support `pyproj>=2.2`

### DIFF
--- a/trefoil/geometry/bbox.py
+++ b/trefoil/geometry/bbox.py
@@ -60,7 +60,11 @@ class BBox(object):
         return info
 
     def is_geographic(self):
-        return self.projection.is_latlong()
+        # `.is_latlong` was removed in pyproj 2.2
+        try:
+            return self.projection.is_latlong()
+        except AttributeError:
+            return self.projection.crs.is_geographic
 
     def project(self, target_projection, edge_points=9):
         """

--- a/trefoil/geometry/bbox.py
+++ b/trefoil/geometry/bbox.py
@@ -3,6 +3,8 @@ from itertools import product
 from pyproj import Proj, transform
 from six import text_type
 
+from trefoil.utilities.proj import is_latlong
+
 
 class BBox(object):
     """
@@ -60,11 +62,7 @@ class BBox(object):
         return info
 
     def is_geographic(self):
-        # `.is_latlong` was removed in pyproj 2.2
-        try:
-            return self.projection.is_latlong()
-        except AttributeError:
-            return self.projection.crs.is_geographic
+        return is_latlong(self.projection)
 
     def project(self, target_projection, edge_points=9):
         """

--- a/trefoil/netcdf/conversion.py
+++ b/trefoil/netcdf/conversion.py
@@ -11,6 +11,7 @@ from trefoil.netcdf.variable import SpatialCoordinateVariables
 from trefoil.geometry.bbox import BBox
 from trefoil.netcdf.crs import get_crs
 from trefoil.utilities.conversion import array_to_raster
+from trefoil.utilities.proj import is_latlong
 
 
 def raster_to_netcdf(filename_or_raster, outfilename=None, variable_name='data', format='NETCDF4', **kwargs):
@@ -45,13 +46,7 @@ def raster_to_netcdf(filename_or_raster, outfilename=None, variable_name='data',
 
     outfilename = outfilename or src.name + '.nc'
     with Dataset(outfilename, 'w', format=format) as target:
-        # `.is_latlong` was removed in pyproj 2.2
-        try:
-            is_latlong = prj.is_latlong()
-        except AttributeError:
-            is_latlong = prj.crs.is_geographic
-
-        if is_latlong:
+        if is_latlong(prj):
             x_varname = 'longitude'
             y_varname = 'latitude'
         else:

--- a/trefoil/netcdf/conversion.py
+++ b/trefoil/netcdf/conversion.py
@@ -45,7 +45,13 @@ def raster_to_netcdf(filename_or_raster, outfilename=None, variable_name='data',
 
     outfilename = outfilename or src.name + '.nc'
     with Dataset(outfilename, 'w', format=format) as target:
-        if prj.is_latlong():
+        # `.is_latlong` was removed in pyproj 2.2
+        try:
+            is_latlong = prj.is_latlong()
+        except AttributeError:
+            is_latlong = prj.crs.is_geographic
+
+        if is_latlong:
             x_varname = 'longitude'
             y_varname = 'latitude'
         else:

--- a/trefoil/netcdf/variable.py
+++ b/trefoil/netcdf/variable.py
@@ -9,6 +9,7 @@ from pyproj import Proj
 import six
 
 from trefoil.geometry.bbox import BBox
+from trefoil.utilities.proj import is_latlong
 from trefoil.utilities.window import Window
 from trefoil.netcdf.utilities import get_ncattrs
 from trefoil.netcdf.crs import PROJ4_GEOGRAPHIC
@@ -356,13 +357,7 @@ class SpatialCoordinateVariables(object):
         y_var.setncattr('axis', 'Y')
 
         if self.projection:
-            # `.is_latlong` was removed in pyproj 2.2
-            try:
-                is_latlong = self.projection.is_latlong()
-            except AttributeError:
-                is_latlong = self.projection.crs.is_geographic
-
-            if is_latlong:
+            if is_latlong(self.projection):
                 x_var.setncattr('standard_name', 'longitude')
                 x_var.setncattr('long_name', 'longitude')
                 x_var.setncattr('units', 'degrees_east')

--- a/trefoil/netcdf/variable.py
+++ b/trefoil/netcdf/variable.py
@@ -356,7 +356,13 @@ class SpatialCoordinateVariables(object):
         y_var.setncattr('axis', 'Y')
 
         if self.projection:
-            if self.projection.is_latlong():
+            # `.is_latlong` was removed in pyproj 2.2
+            try:
+                is_latlong = self.projection.is_latlong()
+            except AttributeError:
+                is_latlong = self.projection.crs.is_geographic
+
+            if is_latlong:
                 x_var.setncattr('standard_name', 'longitude')
                 x_var.setncattr('long_name', 'longitude')
                 x_var.setncattr('units', 'degrees_east')

--- a/trefoil/utilities/proj.py
+++ b/trefoil/utilities/proj.py
@@ -1,0 +1,8 @@
+def is_latlong(p):
+    """ Returns True if the projection uses a lat/long coordinate system """
+
+    # `.is_latlong` was removed in pyproj 2.2
+    try:
+        return p.is_latlong()
+    except AttributeError:
+        return p.crs.is_geographic


### PR DESCRIPTION
`pyproj` dropped the `p.is_latlong()` method starting at version 2.2. This PR uses `p.crs.is_geographic` in its place, but retains the original functionality because `p.crs` wasn't introduced until version 2.